### PR TITLE
Use date-fns v2 adapter

### DIFF
--- a/frontend/src/components/reports/PatientComparisonReport.tsx
+++ b/frontend/src/components/reports/PatientComparisonReport.tsx
@@ -19,7 +19,7 @@ import {
 } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV2';
 import { ja } from 'date-fns/locale';
 import { PatientComparisonReport as PatientComparisonReportType } from '../../types/PatientReport';
 import { PatientReportService } from '../../services/patientReportService';

--- a/frontend/src/components/reports/PatientReport.tsx
+++ b/frontend/src/components/reports/PatientReport.tsx
@@ -24,7 +24,7 @@ import {
 } from '@mui/material';
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV2';
 import { ja } from 'date-fns/locale';
 import { format } from 'date-fns';
 import { Patient } from '../../types/Patient';

--- a/frontend/src/components/visits/DailyVisitRecordForm.tsx
+++ b/frontend/src/components/visits/DailyVisitRecordForm.tsx
@@ -14,7 +14,7 @@ import {
 import { DatePicker } from '@mui/x-date-pickers/DatePicker';
 import { TimePicker } from '@mui/x-date-pickers/TimePicker';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV2';
 import { ja } from 'date-fns/locale';
 import { format } from 'date-fns';
 import { 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,7 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { ThemeProvider, createTheme } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
-import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFnsV2';
 import { ja } from 'date-fns/locale';
 import App from './App';
 


### PR DESCRIPTION
## Summary
- fix rollup build failures by switching to the date-fns v2 adapter
- update all components to import AdapterDateFnsV2

## Testing
- `npm run build` *(fails: Argument for '--moduleResolution' option must be: 'node', 'classic', 'node16', 'nodenext')*
- `npm test` *(fails: 29 failed | 7 passed)*

------
https://chatgpt.com/codex/tasks/task_b_689b6433fd308333b1161fd74f8a7220