### PR TITLE
feat: enrich patient report csv and name display

### DIFF
--- a/backend/src/models/PatientReport.ts
+++ b/backend/src/models/PatientReport.ts
@@ -17,7 +17,7 @@ export class PatientReportModel {
     try {
       // 患者情報を取得
       const patientResult = await pool.query(
-        'SELECT id, name, patient_id FROM patients WHERE id = $1',
+        'SELECT id, name, patient_id, phone, email, address FROM patients WHERE id = $1',
         [params.patientId]
       );
 
@@ -93,6 +93,9 @@ export class PatientReportModel {
       return {
         patientId: patient.id,
         patientName: patient.name,
+        phone: patient.phone,
+        email: patient.email,
+        address: patient.address,
         year: params.year,
         month: params.month,
         totalVisits,

--- a/backend/src/services/__tests__/csvExportService.test.ts
+++ b/backend/src/services/__tests__/csvExportService.test.ts
@@ -8,6 +8,9 @@ describe('CsvExportService', () => {
       const mockData: PatientMonthlyStats = {
         patientId: 1,
         patientName: '田中太郎',
+        phone: '090-1234-5678',
+        email: 'taro@example.com',
+        address: '東京都新宿区1-2-3',
         year: 2024,
         month: 1,
         totalVisits: 5,
@@ -59,6 +62,9 @@ describe('CsvExportService', () => {
       const mockData: PatientMonthlyStats = {
         patientId: 2,
         patientName: '山田花子',
+        phone: '080-0000-0000',
+        email: 'hanako@example.com',
+        address: '大阪府大阪市1-2-3',
         year: 2024,
         month: 2,
         totalVisits: 0,
@@ -161,6 +167,9 @@ describe('CsvExportService', () => {
       const mockData: PatientMonthlyStats = {
         patientId: 1,
         patientName: 'テスト患者',
+        phone: '000',
+        email: 'test@example.com',
+        address: 'Test Address',
         year: 2024,
         month: 1,
         totalVisits: 3,

--- a/backend/src/services/csvExportService.ts
+++ b/backend/src/services/csvExportService.ts
@@ -9,9 +9,15 @@ export class CsvExportService {
    * 患者別レポートをCSV形式に変換
    */
   static convertPatientReportToCsv(data: PatientMonthlyStats): string {
+    const infoRows = [
+      ['患者名', data.patientName],
+      ['患者ID', data.patientId.toString()],
+      ['電話番号', data.phone || ''],
+      ['メールアドレス', data.email || ''],
+      ['住所', data.address || '']
+    ];
+
     const headers = [
-      '患者名',
-      '患者ID', 
       '対象年月',
       '総訪問回数',
       '完了回数',
@@ -26,8 +32,6 @@ export class CsvExportService {
       Math.round((data.completedVisits / data.totalVisits) * 100) : 0;
 
     const summaryRow = [
-      data.patientName,
-      data.patientId.toString(),
       `${data.year}年${data.month}月`,
       data.totalVisits.toString(),
       data.completedVisits.toString(),
@@ -40,16 +44,6 @@ export class CsvExportService {
 
     // 詳細データのヘッダー
     const detailHeaders = [
-      '',
-      '',
-      '',
-      '',
-      '',
-      '',
-      '',
-      '',
-      '',
-      '',
       '訪問日',
       '開始時間',
       '終了時間',
@@ -62,7 +56,6 @@ export class CsvExportService {
     ];
 
     const detailRows = data.visitDetails.map(visit => [
-      '', '', '', '', '', '', '', '', '', '', // 空のセル（サマリー部分）
       visit.visitDate.toLocaleDateString('ja-JP'),
       visit.startTime || '',
       visit.endTime || '',
@@ -75,6 +68,8 @@ export class CsvExportService {
     ]);
 
     const csvRows = [
+      ...infoRows,
+      [],
       headers,
       summaryRow,
       [], // 空行

--- a/backend/src/types/PatientReport.ts
+++ b/backend/src/types/PatientReport.ts
@@ -8,6 +8,9 @@
 export interface PatientMonthlyStats {
   patientId: number;
   patientName: string;
+  phone?: string;
+  email?: string;
+  address?: string;
   year: number;
   month: number;
   totalVisits: number;

--- a/frontend/src/components/reports/HygienistReport.tsx
+++ b/frontend/src/components/reports/HygienistReport.tsx
@@ -82,6 +82,9 @@ export const HygienistReport: React.FC = () => {
     }
   };
 
+  const selectedHygienist = hygienists.find(h => h.id === selectedHygienistId);
+  const displayHygienistName = reportData?.hygienistName || selectedHygienist?.name || '';
+
   // 年の選択肢を生成
   const generateYearOptions = () => {
     const currentYear = new Date().getFullYear();
@@ -239,7 +242,7 @@ export const HygienistReport: React.FC = () => {
             <CardContent>
               <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
                 <Typography variant="h6">
-                  {reportData.hygienistName}さんの{reportData.year}年{reportData.month}月統計
+                  {displayHygienistName}さんの{reportData.year}年{reportData.month}月統計
                 </Typography>
                 <ExportButton
                   onExport={handleCsvExport}

--- a/frontend/src/components/reports/PatientReport.tsx
+++ b/frontend/src/components/reports/PatientReport.tsx
@@ -89,6 +89,9 @@ export const PatientReport: React.FC = () => {
     }
   };
 
+  const selectedPatient = patients.find(p => p.id === selectedPatientId);
+  const displayPatientName = reportData?.patientName || selectedPatient?.name || '';
+
   // 訪問状態のチップ色を取得
   const getStatusChipColor = (status: string) => {
     switch (status) {
@@ -215,7 +218,7 @@ export const PatientReport: React.FC = () => {
               <CardContent>
                 <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
                   <Typography variant="h6">
-                    {reportData.patientName}さんの統計 ({reportData.year}年{reportData.month}月)
+                    {displayPatientName}さんの統計 ({reportData.year}年{reportData.month}月)
                   </Typography>
                   <ExportButton
                     onExport={handleCsvExport}

--- a/frontend/src/types/PatientReport.ts
+++ b/frontend/src/types/PatientReport.ts
@@ -8,6 +8,9 @@
 export interface PatientMonthlyStats {
   patientId: number;
   patientName: string;
+  phone?: string;
+  email?: string;
+  address?: string;
   year: number;
   month: number;
   totalVisits: number;


### PR DESCRIPTION
## Summary
- include patient contact info in patient monthly stats and CSV
- improve report headers to display patient/hygienist names reliably
- restructure patient CSV output with personal info section

## Testing
- `npm test` (backend) *(fails: Test suite failed to run: TS errors and database AggregateError)*
- `npm test` (frontend) *(fails: validationRules test failure and integration tests)*

------
https://chatgpt.com/codex/tasks/task_b_68a303b7c7e083339de3e9efab123665